### PR TITLE
fixed filter configuration

### DIFF
--- a/src/main/java/com/myapp/auth/SecurityConfig.java
+++ b/src/main/java/com/myapp/auth/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.tokenAuthenticationService = tokenAuthenticationService;
     }
 
-    @Bean
+
     public StatelessAuthenticationFilter authenticationTokenFilterBean() throws Exception {
         StatelessAuthenticationFilter authenticationTokenFilter = new StatelessAuthenticationFilter(tokenAuthenticationService);
         return authenticationTokenFilter;


### PR DESCRIPTION
I don't know why but defining the filter as bean create a lot of problem with the context holder.

I tried to debug the middleware but at a certain point the security context holder loosed the Anonymous login toen and returned Null Authentication.

I can't find a solution so I reverted the configuration to a norma encapsulation of the tokenservice.

Let me know if you have a better solution
